### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-ComboView-green.svg?style=true)](https://android-arsenal.com/details/1/3338)
 
 # ComboView
-###A view of clicking effect by combo action
+### A view of clicking effect by combo action
 
 
 # UI Effect
@@ -13,7 +13,7 @@
 ![combo2](./combo2.gif)
 
 
-#How To Use
+# How To Use
 ```java
 
   ComboView.Params params = ComboView.Params.create()


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
